### PR TITLE
Move _p2t_edge_list into a WeakMap on the SweepContext

### DIFF
--- a/src/point.js
+++ b/src/point.js
@@ -23,6 +23,9 @@
 
 var xy = require('./xy');
 
+/** @const */
+var WEAKMAP_AVAILABLE = (typeof WeakMap !== 'undefined');
+
 // ------------------------------------------------------------------------Point
 /**
  * Construct a point
@@ -46,15 +49,20 @@ var Point = function(x, y) {
      */
     this.y = +y || 0;
 
-    // All extra fields added to Point are prefixed with _p2t_
-    // to avoid collisions if custom Point class is used.
+    if (!WEAKMAP_AVAILABLE ) {
+        // Extra fields will be weakly mapped to Point objects if WeakMap is available.
+        // Otherwise, these fields will be added directly to the class.
 
-    /**
-     * The edges this point constitutes an upper ending point
-     * @private
-     * @type {Array.<Edge>}
-     */
-    this._p2t_edge_list = null;
+        // All extra fields added to Point are prefixed with _p2t_
+        // to avoid collisions if custom Point class is used.
+
+        /**
+         * The edges this point constitutes an upper ending point
+         * @private
+         * @type {Array.<Edge>}
+         */
+        this._p2t_edge_list = null;
+    }
 };
 
 /**

--- a/src/sweep.js
+++ b/src/sweep.js
@@ -44,6 +44,9 @@ var utils = require('./utils');
 var EPSILON = utils.EPSILON;
 
 /** @const */
+var WEAKMAP_AVAILABLE = (typeof WeakMap !== 'undefined');
+
+/** @const */
 var Orientation = utils.Orientation;
 /** @const */
 var orient2d = utils.orient2d;
@@ -79,7 +82,12 @@ function sweepPoints(tcx) {
     for (i = 1; i < len; ++i) {
         var point = tcx.getPoint(i);
         var node = pointEvent(tcx, point);
-        var edges = point._p2t_edge_list;
+        var edges;
+        if (WEAKMAP_AVAILABLE) {
+            edges = tcx.edge_list_for_point.get(point);
+        } else {
+            edges = point._p2t_edge_list;
+        }
         for (var j = 0; edges && j < edges.length; ++j) {
             edgeEventByEdge(tcx, edges[j], node);
         }


### PR DESCRIPTION
When WeakMap is available, push the _p2t_edge_list Point property into a WeakMap on the SweepContext. This prevents creating a new hidden class when using a custom Point class, and allows for the edge lists to be garbage collected up with the SweepContext.

The basic functionality of WeakMap is [supported by pretty much everything](http://kangax.github.io/compat-table/es6/#test-WeakMap). However, it is not supported by PhantomJS, so the current behaviour of adding _p2t_edge_list to Points is maintained if WeakMap is not available.